### PR TITLE
Implements the skeletone codes for rive-cpp submodule build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodule"]
+	path = submodule
+	url = https://github.com/taehyub/rive-cpp.git

--- a/example/meson.build
+++ b/example/meson.build
@@ -1,0 +1,8 @@
+source_file = [
+   'rive_viewer.cpp'
+]
+
+executable('rive_viewer',
+           source_file,
+           dependencies : [rive_tizen_lib_dep],
+           install : true)

--- a/example/rive_viewer.cpp
+++ b/example/rive_viewer.cpp
@@ -1,0 +1,7 @@
+#include <rive_tizen.hpp>
+
+int main(int argc, char **argv)
+{
+    rive_tizen_print();
+    return 0;
+}

--- a/inc/rive_tizen.hpp
+++ b/inc/rive_tizen.hpp
@@ -1,0 +1,5 @@
+#include <iostream>
+
+#define RIVE_EXPORT __attribute__ ((visibility ("default")))
+
+RIVE_EXPORT void rive_tizen_print();

--- a/meson.build
+++ b/meson.build
@@ -1,36 +1,57 @@
-project('rive-tizen',
+project('rive_tizen',
         'cpp',
         version : '0.1.0',
         license : 'MIT')
 
-subdir('lib')
+#thorvg_dep = dependency('thorvg', required : true)
 
-thorvg_dep = dependency('thorvg', required : true)
+headers = [include_directories('inc')]
 
-rive-tizen_lib = library(
-	'rive-tizen',
-	include_directories : [headers, math_headers, thorvg_headers],
-	version             : meson.project_version(),
-	dependencies        : [math_dep, rive-tizen_dep, rive-tizen_render_dep, thorvg_dep],
-	install             : true,
-        gnu_symbol_visibility : 'hidden',
+rive_tizen_src = [
+   'src/rive_tizen.cpp',
+]
+
+install_headers([
+                 'inc/rive_tizen.hpp',
+                ])
+
+rive_tizen_dep = declare_dependency(
+   include_directories : include_directories('.'),
+   sources : rive_tizen_src
 )
 
-rive-tizen_lib_dep = declare_dependency(
-	include_directories : [headers, math_headers, thorvg_headers],
-        link_with : rive-tizen_lib
+rive_src = [
+   'submodule/src/math/aabb.cpp',
+   'submodule/src/math/vec2d.cpp',
+]
+
+rive_dep = declare_dependency(
+   include_directories : include_directories(['submodule/include']),
+   sources : rive_src
+)
+
+rive_tizen_lib = library(
+	'rive_tizen',
+	include_directories : [headers],
+	version             : meson.project_version(),
+	dependencies        : [rive_tizen_dep, rive_dep],
+	install             : true,
+	gnu_symbol_visibility : 'hidden',
+)
+
+rive_tizen_lib_dep = declare_dependency(
+	include_directories : [headers],
+	link_with : rive_tizen_lib
 )
 
 pkg_mod = import('pkgconfig')
 
 pkg_mod.generate(
-        libraries    : rive-tizen_lib,
+        libraries    : rive_tizen_lib,
         version      : meson.project_version(),
-        name         : 'librive-tizen',
-        filebase     : 'rive-tizen',
+        name         : 'librive_tizen',
+        filebase     : 'rive_tizen',
         description  : 'A Rive Animation Tizen Runtime Engine'
 )
 
 subdir('example')
-subdir('assets')
-

--- a/script/tizen_build.diff
+++ b/script/tizen_build.diff
@@ -1,0 +1,38 @@
+diff --git include/math/aabb.hpp include/math/aabb.hpp
+index 6e5114e..1824756 100644
+--- include/math/aabb.hpp
++++ include/math/aabb.hpp
+@@ -15,10 +15,6 @@ namespace rive
+ 			float buffer[4];
+ 			struct
+ 			{
+-				Vec2D min, max;
+-			};
+-			struct
+-			{
+ 				float minX, minY, maxX, maxY;
+ 			};
+ 		};
+@@ -48,4 +44,4 @@ namespace rive
+ 		float perimeter() const;
+ 	};
+ } // namespace rive
+-#endif
+\ No newline at end of file
++#endif
+diff --git src/math/aabb.cpp src/math/aabb.cpp
+index 94de5d0..a7ea1db 100644
+--- src/math/aabb.cpp
++++ src/math/aabb.cpp
+@@ -77,9 +77,9 @@ bool AABB::areIdentical(const AABB& a, const AABB& b)
+ 	return a[0] == b[0] && a[1] == b[1] && a[2] == b[2] && a[3] == b[3];
+ }
+ 
+-float AABB::width() const { return max[0] - min[0]; }
++float AABB::width() const { return buffer[2] - buffer[0]; }
+ 
+-float AABB::height() const { return max[1] - min[1]; }
++float AABB::height() const { return buffer[3] - buffer[1]; }
+ 
+ float AABB::perimeter() const
+ {

--- a/src/rive_tizen.cpp
+++ b/src/rive_tizen.cpp
@@ -1,0 +1,10 @@
+#include "rive_tizen.hpp"
+#include "math/aabb.hpp"
+
+void rive_tizen_print()
+{
+   // This line to check calling Rive APIs
+   rive::AABB aabb(0, 0, 100, 100);
+   // This line to check rive_tizen API calls
+   std::cout << "hello rive-tizen" << std::endl;
+}


### PR DESCRIPTION
 This patch implemented the skeletone codes of rive-cpp submodule build
 and the simple example to check the rive-tizen API call.