### PR TITLE
build: add example build option to toggle it.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -128,4 +128,7 @@ pkg_mod.generate(
         description  : 'A Rive Animation Tizen Runtime Engine'
 )
 
-subdir('example')
+if get_option('example') == true
+	message('Enable Examples')
+	subdir('example')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,4 @@
+option('example',
+    type: 'boolean',
+    value: false,
+    description: 'Enable building example')


### PR DESCRIPTION
To enable example building, please add meson option like this:

$meson . build -Dexample=true

This requires Efl Elementary dependency as for UI toolkits.