### PR TITLE
renderer: fix wrong layering order.

### DIFF
--- a/example/rive_viewer.cpp
+++ b/example/rive_viewer.cpp
@@ -119,6 +119,8 @@ static std::vector<std::string> riveFiles(const std::string &dirName)
 
 Eina_Bool animationLoop(void *data)
 {
+    canvas->clear();
+
     double currentTime = ecore_time_get();
     float elapsed = currentTime - lastTime;
     lastTime = currentTime;

--- a/src/renderer/tvg_renderer.cpp
+++ b/src/renderer/tvg_renderer.cpp
@@ -362,17 +362,9 @@ void TvgRenderer::drawPath(RenderPath* path, RenderPaint* paint)
    }
 
    shape->transform({m_Transform[0], m_Transform[2], m_Transform[4], m_Transform[1], m_Transform[3], m_Transform[5], 0, 0, 1});
-
-   if (renderPath->onCanvas())
-   {
-      m_Canvas->update(shape);
-   }
-   else
-   {
-      m_Canvas->push(unique_ptr<Shape>(shape));
-      renderPath->onCanvas(true);
-   }
+   m_Canvas->push(unique_ptr<Paint>(shape->duplicate()));
 }
+
 
 void TvgRenderer::clipPath(RenderPath* path)
 {


### PR DESCRIPTION
we can push paint nodes in order for guarantee the layering,
instead canvas needs to clear it every frames.