### PR TITLE
renderer: optimize path manipulation.

### DIFF
--- a/src/renderer/tvg_renderer.hpp
+++ b/src/renderer/tvg_renderer.hpp
@@ -27,8 +27,6 @@ namespace rive
    {
    private:
       Shape *m_Shape;
-      vector<PathCommand> m_PathType;
-      vector<Vec2D> m_PathPoints;
 
    public:
       TvgRenderPath();


### PR DESCRIPTION
Avoid unnecessary intermediate path data copy
by applying immediate tvg path.