### PR TITLE
example: nullptr setting to prevent invalid access

### DIFF
--- a/example/rive_viewer.cpp
+++ b/example/rive_viewer.cpp
@@ -169,6 +169,7 @@ static void runExample(uint32_t* buffer)
 static void cleanExample()
 {
     delete animationInstance;
+    animationInstance = nullptr;
 }
 
 static void animPopupItemCb(void *data EINA_UNUSED, Evas_Object *obj, void *event_info)

--- a/example/user_interaction_animation_speed.cpp
+++ b/example/user_interaction_animation_speed.cpp
@@ -134,6 +134,7 @@ static void cleanExample()
     for (int i = 0; i < 2; i ++)
     {
        delete animationInstance[i];
+       animationInstance[i] = nullptr;
     }
 }
 

--- a/example/user_interaction_rollinout.cpp
+++ b/example/user_interaction_rollinout.cpp
@@ -132,6 +132,7 @@ static void cleanExample()
     for (int i = 0; i < 2; i ++)
     {
        delete animationInstance[i];
+       animationInstance[i] = nullptr;
     }
 }
 


### PR DESCRIPTION
prevent invalid access


```
Thread 1 "rive_viewer" received signal SIGSEGV, Segmentation fault.
0x0000555555579a28 in rive::LinearAnimation::apply (this=0x555555d6a140, artboard=0x555555e15c80, time=3.54885095e+13, mix=1) at ../submodule/src/animation/linear_animation.cpp:50
50		for (auto object : m_KeyedObjects)
(gdb) bt
#0  0x0000555555579a28 in rive::LinearAnimation::apply (this=0x555555d6a140, artboard=0x555555e15c80, time=3.54885095e+13, mix=1) at ../submodule/src/animation/linear_animation.cpp:50
#1  0x000055555556c42e in rive::LinearAnimationInstance::apply (this=0x55555600b220, artboard=0x555555e15c80, mix=1) at ../submodule/include/animation/linear_animation_instance.hpp:59
#2  0x000055555556a078 in animationLoop (data=0x0) at ../example/rive_viewer.cpp:142
#3  0x00007ffff7029d9f in _ecore_call_task_cb (data=<optimized out>, func=<optimized out>) at ../src/lib/ecore/ecore_private.h:456
#4  _do_tick () at ../src/lib/ecore/ecore_anim.c:500
#5  0x00007ffff702bbd9 in _timer_tick_notify (data=<optimized out>, thread=<optimized out>, msg=0x7fffdc000c60) at ../src/lib/ecore/ecore_anim.c:365
#6  0x00007ffff706b4c9 in _ecore_notify_handler (data=0x7fffdc000c40) at ../src/lib/ecore/ecore_thread.c:280
#7  0x00007ffff70290c0 in _ecore_main_call_flush () at ../src/lib/ecore/ecore.c:1112
#8  0x00007ffff7029182 in _thread_callback (data=<optimized out>, buffer=<optimized out>, nbyte=<optimized out>) at ../src/lib/ecore/ecore.c:1123
#9  0x00007ffff70675f2 in _ecore_pipe_handler_call (p=p@entry=0x555555aeb4b0, buf=0x555555dfd440 "*", len=<optimized out>) at ../src/lib/ecore/ecore_pipe.c:592
#10 0x00007ffff7067eff in _ecore_pipe_read (data=0x555555aeb4b0, fd_handler=<optimized out>) at ../src/lib/ecore/ecore_pipe.c:715
#11 0x00007ffff70324b3 in _ecore_call_fd_cb (fd_handler=0x555555ae9130, data=<optimized out>, func=<optimized out>) at ../src/lib/ecore/ecore_private.h:506
#12 _ecore_main_fd_handlers_call (pd=0x555555ae3ac0, obj=0x400000000088) at ../src/lib/ecore/ecore_main.c:2132
#13 _ecore_main_loop_iterate_internal (obj=obj@entry=0x400000000088, pd=pd@entry=0x555555ae3ac0, once_only=once_only@entry=1) at ../src/lib/ecore/ecore_main.c:2509
#14 0x00007ffff70328e0 in _ecore_main_loop_iterate (obj=0x400000000088, pd=0x555555ae3ac0) at ../src/lib/ecore/ecore_main.c:1133
#15 0x00007ffff7037a75 in _efl_loop_iterate (obj=<optimized out>, pd=<optimized out>) at ../src/lib/ecore/efl_loop.c:45
#16 0x00007ffff7036a46 in efl_loop_iterate (obj=0x400000000088) at src/lib/ecore/efl_loop.eo.c:20
#17 0x00007ffff7032aee in ecore_main_loop_iterate () at ../src/lib/ecore/ecore_main.c:1287
#18 0x00007ffff794fff7 in elm_quicklaunch_sub_shutdown () at ../src/lib/elementary/elm_main.c:910
#19 0x00007ffff79507e2 in elm_shutdown () at ../src/lib/elementary/elm_main.c:489
#20 0x000055555556a8a9 in main (argc=1, argv=0x7fffffffd858) at ../example/rive_viewer.cpp:272

```

