### PR TITLE
Fix issue with nested save and restore

### DIFF
--- a/src/renderer/tvg_renderer.cpp
+++ b/src/renderer/tvg_renderer.cpp
@@ -207,12 +207,17 @@ void TvgLinearGradientBuilder::make(TvgPaint* paint)
 
 void TvgRenderer::save()
 {
-   m_SaveTransform = m_Transform;
+    m_SavedTransforms.push(m_Transform);
 }
 
 void TvgRenderer::restore()
 {
-   m_Transform = m_SaveTransform;
+    // Check shouldn't be needed, but safest to check
+    if (m_SavedTransforms.size() > 0)
+    {
+        m_Transform = m_SavedTransforms.top();
+        m_SavedTransforms.pop();
+    }
 }
 
 void TvgRenderer::transform(const Mat2D& transform)

--- a/src/renderer/tvg_renderer.hpp
+++ b/src/renderer/tvg_renderer.hpp
@@ -3,6 +3,7 @@
 
 #include <thorvg.h>
 #include <vector>
+#include <stack>
 #include "renderer.hpp"
 
 using namespace tvg;
@@ -108,7 +109,7 @@ namespace rive
       Shape* m_ClipPath = nullptr;
       Shape* m_BgClipPath = nullptr;
       Mat2D m_Transform;
-      Mat2D m_SaveTransform;
+      stack<Mat2D> m_SavedTransforms;
 
    public:
       TvgRenderer(Canvas* canvas) : m_Canvas(canvas) {}


### PR DESCRIPTION
Hi @hermet

I found that it is possible for Rive to nest calls to save/restore, so the current solution is not suitable.
Looking at the rive/skia solution, they use a stack. So I have updated to a similar solution.

Some of my test code looked like this:
```
cout << "About to save" << endl;
_renderer->save();
_renderer->transform(transform);
artboard->draw(_renderer);
_renderer->restore();
cout << "Finished restore" << endl;
```

And calling this once results in something like:
```
About to save
save
save
save
restore
save
restore
save
restore
save
restore
restore
restore
Finished restore
```

So nesting of these calls is found in practice :)